### PR TITLE
iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,9 @@ jobs:
       with:
         path: ./node_modules/
         key: ${{ runner.os }}-node_modules
-    - if: steps.npm-cache.outputs.cache-hit != 'true'
-      run: npm install --verbose
 
     - name: Build test
       run: |
         wasm-pack build --verbose
+        npm install --verbose
         npm run build --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,16 @@ jobs:
     - name: Get wasm-pack
       uses: jetli/wasm-pack-action@v0.4.0
 
+    - name: Node cache
+      uses: actions/cache@v4
+      id: npm-cache
+      with:
+        path: ./node_modules/
+        key: ${{ runner.os }}-node_modules
+    - if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: npm install --verbose
+
     - name: Build test
       run: |
         wasm-pack build --verbose
-        npm install --verbose
         npm run build --verbose

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,6 +1,13 @@
 name: Bump Version
 
 on:
+  push:
+    branches:
+      - 'main'
+    paths-ignore:
+      - 'package.json'
+      - 'Cargo.toml'
+
   workflow_dispatch:
     inputs:
       release_type:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = [
     "Document",
     "Window",
     "HtmlCanvasElement",
+    "OesTextureHalfFloat",
     "WebGlRenderingContext",
     "WebGl2RenderingContext",
     "WebGlProgram",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -8,9 +8,9 @@ const params = {
     mode: Mode.DYE,
     simResolution: isMobile() ? Resolution.EIGHT : Resolution.FOUR,
     dyeResolution: isMobile() ? Resolution.FOUR : Resolution.TWO,
-    pointerRadius: 0.2,
+    pointerRadius: isMobile() ? 0.4 : 0.2,
     pointerStrength: 10.0,
-    viscosity: 1.0,
+    viscosity: 0.5,
     dissipation: 2.0,
     curl: 0.25,
     pressure: 0.8,
@@ -93,7 +93,7 @@ const createGUI = () => {
         .onFinishChange(resizeCanvas);
     simulationFolder.add(params, "viscosity", 0.0, 5.0, 0.01).name("Viscosity");
     simulationFolder.add(params, "dissipation", 0.0, 5.0, 0.01).name("Dye diffusion");
-    simulationFolder.add(params, "curl", 0.0, 1.0, 0.01).name("Vorticity amount");
+    simulationFolder.add(params, "curl", 0.0, 2.0, 0.01).name("Vorticity amount");
     simulationFolder.add(params, "pressure", 0.0, 1.0, 0.01).name("Pressure");
     simulationFolder.open();
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -11,7 +11,7 @@ const params = {
     pointerRadius: 0.2,
     pointerStrength: 10.0,
     viscosity: 1.0,
-    dissipation: 1.0,
+    dissipation: 2.0,
     curl: 0.25,
     pressure: 0.8,
     color: defaultColor,

--- a/src/app/style.css
+++ b/src/app/style.css
@@ -46,8 +46,7 @@ canvas {
 
 ul:not(.closed) .link {
     font: 20px/27px "Trebuchet MS", sans-serif !important;
-    padding: 4px !important;
-    padding-left: 8px !important;
+    padding: 4px 4px 4px 12px !important;
     margin-left: 40% !important;
     border-left: 8px solid rgb(230, 29, 95) !important;
     color: rgb(245, 245, 245) !important;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub struct Renderer {
     pressure_buffer: RWTextureBuffer,
     dye_buffer: RWTextureBuffer,
     temp_store: TextureFramebuffer,
+    render_buffer: TextureFramebuffer,
     last_time: f32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ pub struct Renderer {
     pressure_buffer: RWTextureBuffer,
     dye_buffer: RWTextureBuffer,
     temp_store: TextureFramebuffer,
-    render_buffer: TextureFramebuffer,
     last_time: f32,
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -83,6 +83,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGlRenderingContext::FLOAT),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -90,6 +91,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGlRenderingContext::FLOAT),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -97,6 +99,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            WebGlRenderingContext::FLOAT,
             WebGlRenderingContext::LINEAR,
         )?;
 
@@ -105,6 +108,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGlRenderingContext::UNSIGNED_BYTE),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -588,7 +592,8 @@ impl Renderer {
                 gl,
                 width,
                 height,
-                WebGl2RenderingContext::LINEAR,
+                WebGlRenderingContext::FLOAT,
+                WebGlRenderingContext::LINEAR,
             )?;
         }
         
@@ -734,6 +739,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGl2RenderingContext::FLOAT),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -741,6 +747,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGl2RenderingContext::FLOAT),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -748,6 +755,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            WebGl2RenderingContext::FLOAT,
             WebGl2RenderingContext::LINEAR,
         )?;
 
@@ -756,6 +764,7 @@ impl Renderer {
             &gl,
             width,
             height,
+            Some(WebGl2RenderingContext::UNSIGNED_BYTE),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -1239,6 +1248,7 @@ impl Renderer {
                 gl,
                 width,
                 height,
+                WebGl2RenderingContext::FLOAT,
                 WebGl2RenderingContext::LINEAR,
             )?;
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -83,7 +83,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGlRenderingContext::FLOAT),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -91,7 +90,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGlRenderingContext::FLOAT),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -99,7 +97,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            WebGlRenderingContext::FLOAT,
             WebGlRenderingContext::LINEAR,
         )?;
 
@@ -108,7 +105,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGlRenderingContext::UNSIGNED_BYTE),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -592,8 +588,7 @@ impl Renderer {
                 gl,
                 width,
                 height,
-                WebGlRenderingContext::FLOAT,
-                WebGlRenderingContext::LINEAR,
+                WebGl2RenderingContext::LINEAR,
             )?;
         }
         
@@ -739,7 +734,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGl2RenderingContext::FLOAT),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -747,7 +741,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGl2RenderingContext::FLOAT),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -755,7 +748,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            WebGl2RenderingContext::FLOAT,
             WebGl2RenderingContext::LINEAR,
         )?;
 
@@ -764,7 +756,6 @@ impl Renderer {
             &gl,
             width,
             height,
-            Some(WebGl2RenderingContext::UNSIGNED_BYTE),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -1248,7 +1239,6 @@ impl Renderer {
                 gl,
                 width,
                 height,
-                WebGl2RenderingContext::FLOAT,
                 WebGl2RenderingContext::LINEAR,
             )?;
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -104,11 +104,19 @@ impl Renderer {
         )?;
 
         let (width, height) = Renderer::resolution_size(&canvas, dye_resolution);
+        let render_buffer = TextureFramebuffer::new_webgl(
+            &gl,
+            width,
+            height,
+            WebGlRenderingContext::UNSIGNED_BYTE,
+            WebGlRenderingContext::LINEAR,
+        )?;
+
         let dye_buffer = RWTextureBuffer::new_webgl(
             &gl,
             width,
             height,
-            Some(WebGlRenderingContext::UNSIGNED_BYTE),
+            Some(WebGlRenderingContext::FLOAT),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -132,6 +140,7 @@ impl Renderer {
             pressure_buffer,
             dye_buffer,
             temp_store,
+            render_buffer,
             last_time: 0.0,
         })
     }
@@ -290,6 +299,25 @@ impl Renderer {
                 Mode::VELOCITY => self.velocity_buffer.read().bind_webgl(gl, 0)?,
                 Mode::PRESSURE => self.pressure_buffer.read().bind_webgl(gl, 0)?,
             },
+        );
+
+        Renderer::blit_webgl(
+            gl,
+            Some(&self.render_buffer),
+            Some(true),
+        );
+
+        gl.uniform1f(
+            self.copy_program.uniforms.get(shaders::U_FACTOR),
+            1.0,
+        );
+        gl.uniform1f(
+            self.copy_program.uniforms.get(shaders::U_OFFSET),
+            0.0,
+        );
+        gl.uniform1i(
+            self.copy_program.uniforms.get(shaders::U_TEXTURE),
+            self.render_buffer.bind_webgl(gl, 0)?,
         );
 
         Renderer::blit_webgl(
@@ -606,6 +634,17 @@ impl Renderer {
             height,
         )?;
 
+        if width != self.render_buffer.width() || height != self.render_buffer.height() {
+            self.render_buffer.delete_webgl(gl);
+            self.render_buffer = TextureFramebuffer::new_webgl(
+                gl,
+                width,
+                height,
+                WebGlRenderingContext::UNSIGNED_BYTE,
+                WebGlRenderingContext::LINEAR,
+            )?;
+        }
+
         Ok(())
     }
 
@@ -760,11 +799,19 @@ impl Renderer {
         )?;
 
         let (width, height) = Renderer::resolution_size(&canvas, dye_resolution);
+        let render_buffer = TextureFramebuffer::new_webgl2(
+            &gl,
+            width,
+            height,
+            WebGl2RenderingContext::UNSIGNED_BYTE,
+            WebGl2RenderingContext::LINEAR,
+        )?;
+
         let dye_buffer = RWTextureBuffer::new_webgl2(
             &gl,
             width,
             height,
-            Some(WebGl2RenderingContext::UNSIGNED_BYTE),
+            Some(WebGl2RenderingContext::FLOAT),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -788,6 +835,7 @@ impl Renderer {
             pressure_buffer,
             dye_buffer,
             temp_store,
+            render_buffer,
             last_time: 0.0,
         })
     }
@@ -946,6 +994,31 @@ impl Renderer {
                 Mode::VELOCITY => self.velocity_buffer.read().bind_webgl2(gl, 0)?,
                 Mode::PRESSURE => self.pressure_buffer.read().bind_webgl2(gl, 0)?,
             },
+        );
+
+        Renderer::blit_webgl2(
+            gl,
+            Some(&self.render_buffer),
+            Some(true),
+        );
+
+        gl.uniform1f(
+            self.copy_program.uniforms.get(shaders::U_FACTOR),
+            1.0,
+        );
+        gl.uniform1f(
+            self.copy_program.uniforms.get(shaders::U_OFFSET),
+            0.0,
+        );
+        gl.uniform1i(
+            self.copy_program.uniforms.get(shaders::U_TEXTURE),
+            self.render_buffer.bind_webgl2(gl, 0)?,
+        );
+
+        Renderer::blit_webgl2(
+            gl,
+            None,
+            Some(true),
         );
 
         Renderer::blit_webgl2(
@@ -1261,6 +1334,17 @@ impl Renderer {
             width,
             height,
         )?;
+
+        if width != self.render_buffer.width() || height != self.render_buffer.height() {
+            self.render_buffer.delete_webgl2(gl);
+            self.render_buffer = TextureFramebuffer::new_webgl2(
+                gl,
+                width,
+                height,
+                WebGl2RenderingContext::UNSIGNED_BYTE,
+                WebGl2RenderingContext::LINEAR,
+            )?;
+        }
 
         Ok(())
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -104,19 +104,11 @@ impl Renderer {
         )?;
 
         let (width, height) = Renderer::resolution_size(&canvas, dye_resolution);
-        let render_buffer = TextureFramebuffer::new_webgl(
-            &gl,
-            width,
-            height,
-            WebGlRenderingContext::UNSIGNED_BYTE,
-            WebGlRenderingContext::LINEAR,
-        )?;
-
         let dye_buffer = RWTextureBuffer::new_webgl(
             &gl,
             width,
             height,
-            Some(WebGlRenderingContext::FLOAT),
+            Some(WebGlRenderingContext::UNSIGNED_BYTE),
             Some(WebGlRenderingContext::LINEAR),
         )?;
 
@@ -140,7 +132,6 @@ impl Renderer {
             pressure_buffer,
             dye_buffer,
             temp_store,
-            render_buffer,
             last_time: 0.0,
         })
     }
@@ -299,25 +290,6 @@ impl Renderer {
                 Mode::VELOCITY => self.velocity_buffer.read().bind_webgl(gl, 0)?,
                 Mode::PRESSURE => self.pressure_buffer.read().bind_webgl(gl, 0)?,
             },
-        );
-
-        Renderer::blit_webgl(
-            gl,
-            Some(&self.render_buffer),
-            Some(true),
-        );
-
-        gl.uniform1f(
-            self.copy_program.uniforms.get(shaders::U_FACTOR),
-            1.0,
-        );
-        gl.uniform1f(
-            self.copy_program.uniforms.get(shaders::U_OFFSET),
-            0.0,
-        );
-        gl.uniform1i(
-            self.copy_program.uniforms.get(shaders::U_TEXTURE),
-            self.render_buffer.bind_webgl(gl, 0)?,
         );
 
         Renderer::blit_webgl(
@@ -634,17 +606,6 @@ impl Renderer {
             height,
         )?;
 
-        if width != self.render_buffer.width() || height != self.render_buffer.height() {
-            self.render_buffer.delete_webgl(gl);
-            self.render_buffer = TextureFramebuffer::new_webgl(
-                gl,
-                width,
-                height,
-                WebGlRenderingContext::UNSIGNED_BYTE,
-                WebGlRenderingContext::LINEAR,
-            )?;
-        }
-
         Ok(())
     }
 
@@ -799,19 +760,11 @@ impl Renderer {
         )?;
 
         let (width, height) = Renderer::resolution_size(&canvas, dye_resolution);
-        let render_buffer = TextureFramebuffer::new_webgl2(
-            &gl,
-            width,
-            height,
-            WebGl2RenderingContext::UNSIGNED_BYTE,
-            WebGl2RenderingContext::LINEAR,
-        )?;
-
         let dye_buffer = RWTextureBuffer::new_webgl2(
             &gl,
             width,
             height,
-            Some(WebGl2RenderingContext::FLOAT),
+            Some(WebGl2RenderingContext::UNSIGNED_BYTE),
             Some(WebGl2RenderingContext::LINEAR),
         )?;
 
@@ -835,7 +788,6 @@ impl Renderer {
             pressure_buffer,
             dye_buffer,
             temp_store,
-            render_buffer,
             last_time: 0.0,
         })
     }
@@ -994,31 +946,6 @@ impl Renderer {
                 Mode::VELOCITY => self.velocity_buffer.read().bind_webgl2(gl, 0)?,
                 Mode::PRESSURE => self.pressure_buffer.read().bind_webgl2(gl, 0)?,
             },
-        );
-
-        Renderer::blit_webgl2(
-            gl,
-            Some(&self.render_buffer),
-            Some(true),
-        );
-
-        gl.uniform1f(
-            self.copy_program.uniforms.get(shaders::U_FACTOR),
-            1.0,
-        );
-        gl.uniform1f(
-            self.copy_program.uniforms.get(shaders::U_OFFSET),
-            0.0,
-        );
-        gl.uniform1i(
-            self.copy_program.uniforms.get(shaders::U_TEXTURE),
-            self.render_buffer.bind_webgl2(gl, 0)?,
-        );
-
-        Renderer::blit_webgl2(
-            gl,
-            None,
-            Some(true),
         );
 
         Renderer::blit_webgl2(
@@ -1334,17 +1261,6 @@ impl Renderer {
             width,
             height,
         )?;
-
-        if width != self.render_buffer.width() || height != self.render_buffer.height() {
-            self.render_buffer.delete_webgl2(gl);
-            self.render_buffer = TextureFramebuffer::new_webgl2(
-                gl,
-                width,
-                height,
-                WebGl2RenderingContext::UNSIGNED_BYTE,
-                WebGl2RenderingContext::LINEAR,
-            )?;
-        }
 
         Ok(())
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -32,9 +32,9 @@ impl Renderer {
     ) -> Result<Renderer, JsValue> {
         let gl = gl.dyn_into::<WebGlRenderingContext>().unwrap();
 
-        gl.get_extension("OES_texture_float")?;
-        gl.get_extension("OES_texture_float_linear")?;
-        gl.get_extension("WEBGL_color_buffer_float")?;
+        gl.get_extension("OES_texture_half_float")?;
+        gl.get_extension("OES_texture_half_float_linear")?;
+        gl.get_extension("EXT_color_buffer_half_float")?;
         gl.disable(WebGlRenderingContext::BLEND);
 
         let copy_program = ShaderProgram::new_webgl(
@@ -684,7 +684,6 @@ impl Renderer {
     ) -> Result<Renderer, JsValue> {
         let gl = gl.dyn_into::<WebGl2RenderingContext>().unwrap();
 
-        gl.get_extension("OES_texture_float_linear")?;
         gl.get_extension("EXT_color_buffer_float")?;
         gl.disable(WebGl2RenderingContext::BLEND);
 

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -4,6 +4,7 @@ use web_sys::{
     WebGl2RenderingContext,
     WebGlTexture,
     WebGlFramebuffer,
+    OesTextureHalfFloat,
 };
 use std::mem;
 use crate::Renderer;
@@ -49,7 +50,7 @@ impl TextureFramebuffer {
             WebGlRenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+        let data = unsafe { js_sys::Uint16Array::view(&vec![0; (width * height * 4) as usize]) };
         gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
             WebGlRenderingContext::TEXTURE_2D,
             0,
@@ -58,7 +59,7 @@ impl TextureFramebuffer {
             height as i32,
             0,
             WebGlRenderingContext::RGBA,
-            WebGlRenderingContext::FLOAT,
+            OesTextureHalfFloat::HALF_FLOAT_OES,
             Some(&data),
         )?;
         
@@ -111,16 +112,16 @@ impl TextureFramebuffer {
             WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+        let data = unsafe { js_sys::Uint16Array::view(&vec![0; (width * height * 4) as usize]) };
         gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
             WebGl2RenderingContext::TEXTURE_2D,
             0,
-            WebGl2RenderingContext::RGBA32F as i32,
+            WebGl2RenderingContext::RGBA16F as i32,
             width as i32,
             height as i32,
             0,
             WebGl2RenderingContext::RGBA,
-            WebGl2RenderingContext::FLOAT,
+            WebGl2RenderingContext::HALF_FLOAT,
             Some(&data),
         )?;
         

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -22,6 +22,7 @@ impl TextureFramebuffer {
         gl: &WebGlRenderingContext,
         width: u32,
         height: u32,
+        format: u32,
         param: u32,
     ) -> Result<TextureFramebuffer, JsValue> {
         gl.active_texture(WebGlRenderingContext::TEXTURE0);
@@ -49,18 +50,34 @@ impl TextureFramebuffer {
             WebGlRenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
-            WebGlRenderingContext::TEXTURE_2D,
-            0,
-            WebGlRenderingContext::RGBA as i32,
-            width as i32,
-            height as i32,
-            0,
-            WebGlRenderingContext::RGBA,
-            WebGlRenderingContext::FLOAT,
-            Some(&data),
-        )?;
+        match format {
+            WebGlRenderingContext::FLOAT => {
+                let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
+                    WebGlRenderingContext::TEXTURE_2D,
+                    0,
+                    WebGlRenderingContext::RGBA as i32,
+                    width as i32,
+                    height as i32,
+                    0,
+                    WebGlRenderingContext::RGBA,
+                    WebGlRenderingContext::FLOAT,
+                    Some(&data),
+                )?;
+            },
+            WebGlRenderingContext::UNSIGNED_BYTE => gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                WebGlRenderingContext::TEXTURE_2D,
+                0,
+                WebGlRenderingContext::RGBA as i32,
+                width as i32,
+                height as i32,
+                0,
+                WebGlRenderingContext::RGBA,
+                WebGlRenderingContext::UNSIGNED_BYTE,
+                Some(&vec![0; (width * height * 4) as usize]),
+            )?,
+            _ => return Err(JsValue::from_str("Incorrect format")),
+        };
         
         let framebuffer = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(WebGlRenderingContext::FRAMEBUFFER, Some(&framebuffer));
@@ -84,6 +101,7 @@ impl TextureFramebuffer {
         gl: &WebGl2RenderingContext,
         width: u32,
         height: u32,
+        format: u32,
         param: u32,
     ) -> Result<TextureFramebuffer, JsValue> {
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -111,18 +129,34 @@ impl TextureFramebuffer {
             WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
-            WebGl2RenderingContext::TEXTURE_2D,
-            0,
-            WebGl2RenderingContext::RGBA32F as i32,
-            width as i32,
-            height as i32,
-            0,
-            WebGl2RenderingContext::RGBA,
-            WebGl2RenderingContext::FLOAT,
-            Some(&data),
-        )?;
+        match format {
+            WebGl2RenderingContext::FLOAT => {
+                let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
+                    WebGl2RenderingContext::TEXTURE_2D,
+                    0,
+                    WebGl2RenderingContext::RGBA32F as i32,
+                    width as i32,
+                    height as i32,
+                    0,
+                    WebGl2RenderingContext::RGBA,
+                    WebGl2RenderingContext::FLOAT,
+                    Some(&data),
+                )?;
+            },
+            WebGl2RenderingContext::UNSIGNED_BYTE => gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                WebGl2RenderingContext::TEXTURE_2D,
+                0,
+                WebGl2RenderingContext::RGBA as i32,
+                width as i32,
+                height as i32,
+                0,
+                WebGl2RenderingContext::RGBA,
+                WebGl2RenderingContext::UNSIGNED_BYTE,
+                Some(&vec![0; (width * height * 4) as usize]),
+            )?,
+            _ => return Err(JsValue::from_str("Incorrect format")),
+        };
         
         let framebuffer = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&framebuffer));
@@ -202,6 +236,7 @@ impl TextureFramebuffer {
 pub struct RWTextureBuffer {
     read: TextureFramebuffer,
     write: TextureFramebuffer,
+    format: u32,
     param: u32,
 }
 
@@ -210,26 +245,31 @@ impl RWTextureBuffer {
         gl: &WebGlRenderingContext,
         width: u32,
         height: u32,
+        format: Option<u32>,
         param: Option<u32>,
     ) -> Result<RWTextureBuffer, JsValue> {
+        let format = format.unwrap_or(WebGlRenderingContext::UNSIGNED_BYTE);
         let param = param.unwrap_or(WebGlRenderingContext::LINEAR);
 
         let read = TextureFramebuffer::new_webgl(
             gl,
             width,
             height,
+            format,
             param,
         )?;
         let write = TextureFramebuffer::new_webgl(
             gl,
             width,
             height,
+            format,
             param,
         )?;
 
         Ok(RWTextureBuffer {
             read,
             write,
+            format,
             param,
         })
     }
@@ -238,26 +278,31 @@ impl RWTextureBuffer {
         gl: &WebGl2RenderingContext,
         width: u32,
         height: u32,
+        format: Option<u32>,
         param: Option<u32>,
     ) -> Result<RWTextureBuffer, JsValue> {
+        let format = format.unwrap_or(WebGl2RenderingContext::UNSIGNED_BYTE);
         let param = param.unwrap_or(WebGl2RenderingContext::LINEAR);
 
         let read = TextureFramebuffer::new_webgl2(
             gl,
             width,
             height,
+            format,
             param,
         )?;
         let write = TextureFramebuffer::new_webgl2(
             gl,
             width,
             height,
+            format,
             param,
         )?;
 
         Ok(RWTextureBuffer {
             read,
             write,
+            format,
             param,
         })
     }
@@ -276,7 +321,8 @@ impl RWTextureBuffer {
         let new_buffer = RWTextureBuffer::new_webgl(
             gl,
             width,
-            height, 
+            height,
+            Some(self.format),
             Some(self.param),
         )?;
 
@@ -327,7 +373,8 @@ impl RWTextureBuffer {
         let new_buffer = RWTextureBuffer::new_webgl2(
             gl,
             width,
-            height, 
+            height,
+            Some(self.format),
             Some(self.param),
         )?;
 

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -22,7 +22,6 @@ impl TextureFramebuffer {
         gl: &WebGlRenderingContext,
         width: u32,
         height: u32,
-        format: u32,
         param: u32,
     ) -> Result<TextureFramebuffer, JsValue> {
         gl.active_texture(WebGlRenderingContext::TEXTURE0);
@@ -50,34 +49,18 @@ impl TextureFramebuffer {
             WebGlRenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        match format {
-            WebGlRenderingContext::FLOAT => {
-                let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
-                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
-                    WebGlRenderingContext::TEXTURE_2D,
-                    0,
-                    WebGlRenderingContext::RGBA as i32,
-                    width as i32,
-                    height as i32,
-                    0,
-                    WebGlRenderingContext::RGBA,
-                    WebGlRenderingContext::FLOAT,
-                    Some(&data),
-                )?;
-            },
-            WebGlRenderingContext::UNSIGNED_BYTE => gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-                WebGlRenderingContext::TEXTURE_2D,
-                0,
-                WebGlRenderingContext::RGBA as i32,
-                width as i32,
-                height as i32,
-                0,
-                WebGlRenderingContext::RGBA,
-                WebGlRenderingContext::UNSIGNED_BYTE,
-                Some(&vec![0; (width * height * 4) as usize]),
-            )?,
-            _ => return Err(JsValue::from_str("Incorrect format")),
-        };
+        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
+            WebGlRenderingContext::TEXTURE_2D,
+            0,
+            WebGlRenderingContext::RGBA as i32,
+            width as i32,
+            height as i32,
+            0,
+            WebGlRenderingContext::RGBA,
+            WebGlRenderingContext::FLOAT,
+            Some(&data),
+        )?;
         
         let framebuffer = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(WebGlRenderingContext::FRAMEBUFFER, Some(&framebuffer));
@@ -101,7 +84,6 @@ impl TextureFramebuffer {
         gl: &WebGl2RenderingContext,
         width: u32,
         height: u32,
-        format: u32,
         param: u32,
     ) -> Result<TextureFramebuffer, JsValue> {
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -129,34 +111,18 @@ impl TextureFramebuffer {
             WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
         );
 
-        match format {
-            WebGl2RenderingContext::FLOAT => {
-                let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
-                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
-                    WebGl2RenderingContext::TEXTURE_2D,
-                    0,
-                    WebGl2RenderingContext::RGBA32F as i32,
-                    width as i32,
-                    height as i32,
-                    0,
-                    WebGl2RenderingContext::RGBA,
-                    WebGl2RenderingContext::FLOAT,
-                    Some(&data),
-                )?;
-            },
-            WebGl2RenderingContext::UNSIGNED_BYTE => gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-                WebGl2RenderingContext::TEXTURE_2D,
-                0,
-                WebGl2RenderingContext::RGBA as i32,
-                width as i32,
-                height as i32,
-                0,
-                WebGl2RenderingContext::RGBA,
-                WebGl2RenderingContext::UNSIGNED_BYTE,
-                Some(&vec![0; (width * height * 4) as usize]),
-            )?,
-            _ => return Err(JsValue::from_str("Incorrect format")),
-        };
+        let data = unsafe { js_sys::Float32Array::view(&vec![0.0; (width * height * 4) as usize]) };
+        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
+            WebGl2RenderingContext::TEXTURE_2D,
+            0,
+            WebGl2RenderingContext::RGBA32F as i32,
+            width as i32,
+            height as i32,
+            0,
+            WebGl2RenderingContext::RGBA,
+            WebGl2RenderingContext::FLOAT,
+            Some(&data),
+        )?;
         
         let framebuffer = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&framebuffer));
@@ -236,7 +202,6 @@ impl TextureFramebuffer {
 pub struct RWTextureBuffer {
     read: TextureFramebuffer,
     write: TextureFramebuffer,
-    format: u32,
     param: u32,
 }
 
@@ -245,31 +210,26 @@ impl RWTextureBuffer {
         gl: &WebGlRenderingContext,
         width: u32,
         height: u32,
-        format: Option<u32>,
         param: Option<u32>,
     ) -> Result<RWTextureBuffer, JsValue> {
-        let format = format.unwrap_or(WebGlRenderingContext::UNSIGNED_BYTE);
         let param = param.unwrap_or(WebGlRenderingContext::LINEAR);
 
         let read = TextureFramebuffer::new_webgl(
             gl,
             width,
             height,
-            format,
             param,
         )?;
         let write = TextureFramebuffer::new_webgl(
             gl,
             width,
             height,
-            format,
             param,
         )?;
 
         Ok(RWTextureBuffer {
             read,
             write,
-            format,
             param,
         })
     }
@@ -278,31 +238,26 @@ impl RWTextureBuffer {
         gl: &WebGl2RenderingContext,
         width: u32,
         height: u32,
-        format: Option<u32>,
         param: Option<u32>,
     ) -> Result<RWTextureBuffer, JsValue> {
-        let format = format.unwrap_or(WebGl2RenderingContext::UNSIGNED_BYTE);
         let param = param.unwrap_or(WebGl2RenderingContext::LINEAR);
 
         let read = TextureFramebuffer::new_webgl2(
             gl,
             width,
             height,
-            format,
             param,
         )?;
         let write = TextureFramebuffer::new_webgl2(
             gl,
             width,
             height,
-            format,
             param,
         )?;
 
         Ok(RWTextureBuffer {
             read,
             write,
-            format,
             param,
         })
     }
@@ -321,8 +276,7 @@ impl RWTextureBuffer {
         let new_buffer = RWTextureBuffer::new_webgl(
             gl,
             width,
-            height,
-            Some(self.format),
+            height, 
             Some(self.param),
         )?;
 
@@ -373,8 +327,7 @@ impl RWTextureBuffer {
         let new_buffer = RWTextureBuffer::new_webgl2(
             gl,
             width,
-            height,
-            Some(self.format),
+            height, 
             Some(self.param),
         )?;
 


### PR DESCRIPTION
## Issue/feature
This fix has been made in response to issue #9

## Description
This pull request aims to provide support for iOS devices by using half float textures for the simulation and rendering. It will undoubtedly introduce some inaccuracy but not on a noticeable level. Some small tweaks to actions and the GUI has also been made.

**Old description**
> ## Description
> This pull request aims to provide support for iOS devices by introducing a render buffer which acts like a middlehand for rendering to the canvas. Some small tweaks to actions and the GUI has also been made.